### PR TITLE
Round robin operation when multiple thrift nodes are spefified

### DIFF
--- a/out_flume.rb
+++ b/out_flume.rb
@@ -49,6 +49,7 @@ module Fluent
       return if chunk.empty?
 
       error = nil
+
       @nodes << @nodes.shift
       @nodes.each do |node|
         begin

--- a/out_flume.rb
+++ b/out_flume.rb
@@ -49,7 +49,7 @@ module Fluent
       return if chunk.empty?
 
       error = nil
-
+      @nodes << @nodes.shift
       @nodes.each do |node|
         begin
           send_data(node.client, chunk)


### PR DESCRIPTION
Using shift to rotate the thrift hosts in the array to send data in round-robin manner 
